### PR TITLE
Novo campo nossoNumero disponível na API de cobrança Unicred - Consulta de Títulos de Cobrança

### DIFF
--- a/src/Unicred/Request/ConsultBankSlipRequest.php
+++ b/src/Unicred/Request/ConsultBankSlipRequest.php
@@ -63,6 +63,10 @@ class ConsultBankSlipRequest extends AbstractRequest
         $param->setBarcode($response->codBarras);
         $param->setDigitableLine($response->linhaDigitavel);
 
+        if ($response->nossoNumero) {
+            $param->setBankSlipNumber(substr($response->nossoNumero, 0, -1));
+        }
+
         return $param;
     }
 


### PR DESCRIPTION
Atendendo a solicitações de usuários da API de cobrança Unicred, estamos melhorando a “Consulta de Títulos de Cobrança”, no que se refere ao ‘Corpo da resposta, quando correto’.

A melhoria consiste em adicionar um novo campo chamado “nossoNumero”, que facilitará a identificação do mesmo, quando inserido pelo APP do usuário ou gerado pelo sistema de cobrança Unicred.

Novo Corpo da resposta:
{
"codBarras": "00000000000000000000000000000000000000000000",
"linhaDigitavel": "0000000000000000000000000000000000000000000000",
"nossoNumero": "00000231444",
"vencimento": "YYYY-MM-DD",
"valor": 1,00,
"status": "ABERTO",
"motivo": null
}

Campo | Tipo | Tamanho | Regra
-- | -- | -- | --
codBarras | Texto | 44 |  
linhaDigitavel | Texto | 46 |  
nossoNumero | Texto | 11 |  
vencimento | Data | 10 | Formato YYYY-MM-DD
status | Texto | 30 |  
motivo | Texto | 20

Solicitamos que os usuários da API, “Consulta de Títulos de Cobrança”, refaçam os testes em nosso ambiente de HOMOLOGAÇÃO.

Disponibilizaremos, aos usuários, um período de 5 dias uteis, a partir de 12/11/2020, para HOMOLOGAÇÃO de seus APPs e após esse período implementaremos o Novo Corpo da resposta em ambiente de produção.